### PR TITLE
Add batch processing for Notion blocks 

### DIFF
--- a/examples/temp.py
+++ b/examples/temp.py
@@ -32,8 +32,18 @@ async def main():
         print(f'✅ Found: "{title}" {icon} → {url}')
 
         markdown_content = """
-+++ This is a toggle block
-   This is the content of the toggle block.
++# Projektübersicht
+  Dies ist ein Überblick über das Projekt.
+
++## Technische Details
+  Hier sind die technischen Spezifikationen.
+  - Punkt 1
+  - Punkt 2
+
++### Implementierungshinweise
+  Detaillierte Informationen zur Implementierung.
+  
+  Sogar mit Absätzen.
         """
 
         await page.append_markdown(markdown_content)


### PR DESCRIPTION
I ran into an issue using your amazing package when I was trying to use append markdown as I was trying to append more than 100 blocks and the batch logic from replace_content wasn't replicated in append_markdown so I have added it in.

I also fixed a bug related to the divider option as it wasn't being set.

Your package came along at exactly the right time as I was about to attempt to port 

https://github.com/TomFrankly/notion-helper/tree/main

to python, so you save me a load of work - and your package is actually lightyears ahead!

If I can contribute in anyway, just let me know.