### PR TITLE
equation_handler: Fix invalid escape sequence in equation_handler docstring

### DIFF
--- a/notionary/page/writer/handler/equation_handler.py
+++ b/notionary/page/writer/handler/equation_handler.py
@@ -8,7 +8,7 @@ from notionary.page.writer.handler.line_handler import (
 
 
 class EquationHandler(LineHandler):
-    """Handles equation block specific logic with batching.
+    r"""Handles equation block specific logic with batching.
 
     Markdown syntax:
     $$


### PR DESCRIPTION
## Summary

  - Fix SyntaxWarning for invalid escape sequences in equation_handler.py docstring
  - Convert docstring to raw string to properly handle LaTeX syntax

## Problem

  Python 3.12+ raises a SyntaxWarning when encountering invalid escape sequences like \s in regular strings. The docstring in equation_handler.py:11 contained LaTeX mathematical expressions with backslashes (\sum, \frac, \left)
  that were being interpreted as escape sequences.

## Solution

  Added the r prefix to make the docstring a raw string, which tells Python to treat backslashes as literal characters rather than escape sequences. This is the standard approach for strings containing LaTeX, regular expressions,
   or file paths.